### PR TITLE
custom delft train args fork

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -211,12 +211,13 @@ public class DeLFTModel {
     }
 
     protected static List<String> getTrainCommand(String modelName, File trainingData) {
-        List<String> command = Arrays.asList("python3", 
+        List<String> command = new ArrayList<>(Arrays.asList("python3", 
             "grobidTagger.py", 
             modelName,
             "train",
             "--input", trainingData.getAbsolutePath(),
-            "--output", GrobidProperties.getModelPath().getAbsolutePath());
+            "--output", GrobidProperties.getModelPath().getAbsolutePath()
+        ));
         if (GrobidProperties.useELMo()) {
             command.add("--use-ELMo");
         }

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -210,9 +210,7 @@ public class DeLFTModel {
         } 
     }
 
-    protected static List<String> getTrainCommand(
-        String modelName, File trainingData, File outputModel
-    ) {
+    protected static List<String> getTrainCommand(String modelName, File trainingData) {
         List<String> command = Arrays.asList("python3", 
             "grobidTagger.py", 
             modelName,
@@ -232,7 +230,7 @@ public class DeLFTModel {
     public static void train(String modelName, File trainingData, File outputModel) {
         try {
             LOGGER.info("Train DeLFT model " + modelName + "...");
-            List<String> command = getTrainCommand(modelName, trainingData, outputModel);
+            List<String> command = getTrainCommand(modelName, trainingData);
             LOGGER.info("Running: {}", command);
 
             ProcessBuilder pb = new ProcessBuilder(command);

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -213,8 +213,12 @@ public class DeLFTModel {
     }
 
     protected static List<String> getTrainCommand(String modelName, File trainingData) {
+        String trainModule = GrobidProperties.getDeLFTTrainModule();
+        if (StringUtils.isEmpty(trainModule)) {
+            trainModule = "grobidTagger.py";
+        }
         List<String> command = new ArrayList<>(Arrays.asList("python3", 
-            "grobidTagger.py", 
+            trainModule,
             modelName,
             "train",
             "--input", trainingData.getAbsolutePath(),

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -224,7 +224,9 @@ public class DeLFTModel {
             command.add("--use-ELMo");
         }
         if (StringUtils.isNotEmpty(GrobidProperties.getDeLFTTrainArgs())) {
-            command.add(GrobidProperties.getDeLFTTrainArgs());
+            command.addAll(Arrays.asList(
+                GrobidProperties.getDeLFTTrainArgs().split(" ")
+            ));
         }
         return command;
     }

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -208,7 +208,22 @@ public class DeLFTModel {
                 LOGGER.error("DeLFT model training via JEP failed", e);
             } 
         } 
-    } 
+    }
+
+    protected static List<String> getTrainCommand(
+        String modelName, File trainingData, File outputModel
+    ) {
+        List<String> command = Arrays.asList("python3", 
+            "grobidTagger.py", 
+            modelName,
+            "train",
+            "--input", trainingData.getAbsolutePath(),
+            "--output", GrobidProperties.getInstance().getModelPath().getAbsolutePath());
+        if (GrobidProperties.getInstance().useELMo()) {
+            command.add("--use-ELMo");
+        }
+        return command;
+    }
 
     /**
      *  Train with an external process rather than with JNI, this approach appears to be more stable for the
@@ -217,15 +232,7 @@ public class DeLFTModel {
     public static void train(String modelName, File trainingData, File outputModel) {
         try {
             LOGGER.info("Train DeLFT model " + modelName + "...");
-            List<String> command = Arrays.asList("python3", 
-                "grobidTagger.py", 
-                modelName,
-                "train",
-                "--input", trainingData.getAbsolutePath(),
-                "--output", GrobidProperties.getInstance().getModelPath().getAbsolutePath());
-            if (GrobidProperties.getInstance().useELMo()) {
-                command.add("--use-ELMo");
-            }
+            List<String> command = getTrainCommand(modelName, trainingData, outputModel);
 
             ProcessBuilder pb = new ProcessBuilder(command);
             File delftPath = new File(GrobidProperties.getInstance().getDeLFTFilePath());

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -1,5 +1,7 @@
 package org.grobid.core.jni;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.grobid.core.GrobidModel;
 import org.grobid.core.GrobidModels;
 import org.grobid.core.exceptions.GrobidException;
@@ -220,6 +222,9 @@ public class DeLFTModel {
         ));
         if (GrobidProperties.useELMo()) {
             command.add("--use-ELMo");
+        }
+        if (StringUtils.isNotEmpty(GrobidProperties.getDeLFTTrainArgs())) {
+            command.add(GrobidProperties.getDeLFTTrainArgs());
         }
         return command;
     }

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -233,6 +233,7 @@ public class DeLFTModel {
         try {
             LOGGER.info("Train DeLFT model " + modelName + "...");
             List<String> command = getTrainCommand(modelName, trainingData, outputModel);
+            LOGGER.info("Running: {}", command);
 
             ProcessBuilder pb = new ProcessBuilder(command);
             File delftPath = new File(GrobidProperties.getInstance().getDeLFTFilePath());

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -216,8 +216,8 @@ public class DeLFTModel {
             modelName,
             "train",
             "--input", trainingData.getAbsolutePath(),
-            "--output", GrobidProperties.getInstance().getModelPath().getAbsolutePath());
-        if (GrobidProperties.getInstance().useELMo()) {
+            "--output", GrobidProperties.getModelPath().getAbsolutePath());
+        if (GrobidProperties.useELMo()) {
             command.add("--use-ELMo");
         }
         return command;

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -435,6 +435,12 @@ public class GrobidProperties {
         return pathFile.getAbsolutePath();
     }
 
+    public static String getDeLFTTrainModule() {
+        return getPropertyValue(
+            GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_MODULE, ""
+        );
+    }
+
     public static String getDeLFTTrainArgs() {
         return getPropertyValue(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "");
     }

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -435,6 +435,10 @@ public class GrobidProperties {
         return pathFile.getAbsolutePath();
     }
 
+    public static String getDeLFTTrainArgs() {
+        return getPropertyValue(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "");
+    }
+
     public static String getGluttonHost() {
         return getPropertyValue(GrobidPropertyKeys.PROP_GLUTTON_HOST);
     }

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
@@ -19,6 +19,7 @@ public interface GrobidPropertyKeys {
     String PROP_GROBID_CRF_ENGINE = "grobid.crf.engine";
     String PROP_GROBID_DELFT_PATH = "grobid.delft.install";
     String PROP_GROBID_DELFT_ELMO = "grobid.delft.useELMo";
+    String PROP_GROBID_DELFT_TRAIN_ARGS = "grobid.delft.train.args";
     String PROP_USE_LANG_ID = "grobid.use_language_id";
     String PROP_LANG_DETECTOR_FACTORY = "grobid.language_detector_factory";
 

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
@@ -19,6 +19,7 @@ public interface GrobidPropertyKeys {
     String PROP_GROBID_CRF_ENGINE = "grobid.crf.engine";
     String PROP_GROBID_DELFT_PATH = "grobid.delft.install";
     String PROP_GROBID_DELFT_ELMO = "grobid.delft.useELMo";
+    String PROP_GROBID_DELFT_TRAIN_MODULE = "grobid.delft.train.module";
     String PROP_GROBID_DELFT_TRAIN_ARGS = "grobid.delft.train.args";
     String PROP_USE_LANG_ID = "grobid.use_language_id";
     String PROP_LANG_DETECTOR_FACTORY = "grobid.language_detector_factory";

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -66,7 +66,7 @@ public class DeLFTModelTest {
     }
 
     @Test
-    public void testShouldAddSingleCustomArg() {
+    public void testShouldAddSingleCustomTrainArg() {
         GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "arg1");
         File trainingData = new File("test/train.data");
         assertThat(
@@ -81,7 +81,7 @@ public class DeLFTModelTest {
     }
 
     @Test
-    public void testShouldAddMultipleCustomArg() {
+    public void testShouldAddMultipleCustomTrainArg() {
         GrobidProperties.getProps().put(
             GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "arg1 arg2"
         );

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -62,4 +62,22 @@ public class DeLFTModelTest {
             )
         );
     }
+
+    @Test
+    public void testShouldAddMultipleCustomArg() {
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "arg1 arg2"
+        );
+        File trainingData = new File("test/train.data");
+        assertThat(
+            DeLFTModel.getTrainCommand("model1", trainingData),
+            contains(
+                "python3", "grobidTagger.py", "model1", "train",
+                "--input", trainingData.getAbsolutePath(),
+                "--output", GrobidProperties.getModelPath().getAbsolutePath(),
+                "arg1",
+                "arg2"
+            )
+        );
+    }
 }

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -17,6 +17,7 @@ public class DeLFTModelTest {
     public void setUp() {
         GrobidProperties.getInstance();
         GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_ELMO, "false");
+        GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_MODULE);
         GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS);
     }
 
@@ -44,6 +45,22 @@ public class DeLFTModelTest {
                 "--input", trainingData.getAbsolutePath(),
                 "--output", GrobidProperties.getModelPath().getAbsolutePath(),
                 "--use-ELMo"
+            )
+        );
+    }
+
+    @Test
+    public void testShouldUseCustomTrainModule() {
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_MODULE, "module1.py"
+        );
+        File trainingData = new File("test/train.data");
+        assertThat(
+            DeLFTModel.getTrainCommand("model1", trainingData),
+            contains(
+                "python3", "module1.py", "model1", "train",
+                "--input", trainingData.getAbsolutePath(),
+                "--output", GrobidProperties.getModelPath().getAbsolutePath()
             )
         );
     }

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -1,0 +1,27 @@
+package org.grobid.core.jni;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+import org.grobid.core.utilities.GrobidProperties;
+
+
+public class DeLFTModelTest {
+    @Test
+    public void testShouldBuildTrainCommand() {
+        File trainingData = new File("test/train.data");
+        File outputModel = new File("test/output");
+        assertThat(
+            DeLFTModel.getTrainCommand("model1", trainingData, outputModel),
+            contains(
+                "python3", "grobidTagger.py", "model1", "train",
+                "--input", trainingData.getAbsolutePath(),
+                "--output", GrobidProperties.getModelPath().getAbsolutePath()
+            )
+        );
+    }
+}

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -13,6 +13,7 @@ import org.grobid.core.utilities.GrobidProperties;
 public class DeLFTModelTest {
     @Test
     public void testShouldBuildTrainCommand() {
+        GrobidProperties.getInstance();
         File trainingData = new File("test/train.data");
         assertThat(
             DeLFTModel.getTrainCommand("model1", trainingData),

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -13,6 +13,8 @@ import org.grobid.core.utilities.GrobidPropertyKeys;
 
 
 public class DeLFTModelTest {
+    private File trainingData = new File("test/train.data");
+
     @Before
     public void setUp() {
         GrobidProperties.getInstance();
@@ -23,12 +25,11 @@ public class DeLFTModelTest {
 
     @Test
     public void testShouldBuildTrainCommand() {
-        File trainingData = new File("test/train.data");
         assertThat(
             DeLFTModel.getTrainCommand("model1", trainingData),
             contains(
                 "python3", "grobidTagger.py", "model1", "train",
-                "--input", trainingData.getAbsolutePath(),
+                "--input", this.trainingData.getAbsolutePath(),
                 "--output", GrobidProperties.getModelPath().getAbsolutePath()
             )
         );
@@ -37,12 +38,11 @@ public class DeLFTModelTest {
     @Test
     public void testShouldAddUseELMO() {
         GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_ELMO, "true");
-        File trainingData = new File("test/train.data");
         assertThat(
             DeLFTModel.getTrainCommand("model1", trainingData),
             contains(
                 "python3", "grobidTagger.py", "model1", "train",
-                "--input", trainingData.getAbsolutePath(),
+                "--input", this.trainingData.getAbsolutePath(),
                 "--output", GrobidProperties.getModelPath().getAbsolutePath(),
                 "--use-ELMo"
             )
@@ -54,12 +54,11 @@ public class DeLFTModelTest {
         GrobidProperties.getProps().put(
             GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_MODULE, "module1.py"
         );
-        File trainingData = new File("test/train.data");
         assertThat(
             DeLFTModel.getTrainCommand("model1", trainingData),
             contains(
                 "python3", "module1.py", "model1", "train",
-                "--input", trainingData.getAbsolutePath(),
+                "--input", this.trainingData.getAbsolutePath(),
                 "--output", GrobidProperties.getModelPath().getAbsolutePath()
             )
         );
@@ -68,12 +67,11 @@ public class DeLFTModelTest {
     @Test
     public void testShouldAddSingleCustomTrainArg() {
         GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "arg1");
-        File trainingData = new File("test/train.data");
         assertThat(
             DeLFTModel.getTrainCommand("model1", trainingData),
             contains(
                 "python3", "grobidTagger.py", "model1", "train",
-                "--input", trainingData.getAbsolutePath(),
+                "--input", this.trainingData.getAbsolutePath(),
                 "--output", GrobidProperties.getModelPath().getAbsolutePath(),
                 "arg1"
             )
@@ -85,12 +83,11 @@ public class DeLFTModelTest {
         GrobidProperties.getProps().put(
             GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "arg1 arg2"
         );
-        File trainingData = new File("test/train.data");
         assertThat(
             DeLFTModel.getTrainCommand("model1", trainingData),
             contains(
                 "python3", "grobidTagger.py", "model1", "train",
-                "--input", trainingData.getAbsolutePath(),
+                "--input", this.trainingData.getAbsolutePath(),
                 "--output", GrobidProperties.getModelPath().getAbsolutePath(),
                 "arg1",
                 "arg2"

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
 import org.grobid.core.utilities.GrobidProperties;
+import org.grobid.core.utilities.GrobidPropertyKeys;
 
 
 public class DeLFTModelTest {
@@ -21,6 +22,22 @@ public class DeLFTModelTest {
                 "python3", "grobidTagger.py", "model1", "train",
                 "--input", trainingData.getAbsolutePath(),
                 "--output", GrobidProperties.getModelPath().getAbsolutePath()
+            )
+        );
+    }
+
+    @Test
+    public void testShouldAddUseELMO() {
+        GrobidProperties.getInstance();
+        GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_ELMO, "true");
+        File trainingData = new File("test/train.data");
+        assertThat(
+            DeLFTModel.getTrainCommand("model1", trainingData),
+            contains(
+                "python3", "grobidTagger.py", "model1", "train",
+                "--input", trainingData.getAbsolutePath(),
+                "--output", GrobidProperties.getModelPath().getAbsolutePath(),
+                "--use-ELMo"
             )
         );
     }

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -2,6 +2,7 @@ package org.grobid.core.jni;
 
 import java.io.File;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -12,9 +13,15 @@ import org.grobid.core.utilities.GrobidPropertyKeys;
 
 
 public class DeLFTModelTest {
+    @Before
+    public void setUp() {
+        GrobidProperties.getInstance();
+        GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_ELMO, "false");
+        GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS);
+    }
+
     @Test
     public void testShouldBuildTrainCommand() {
-        GrobidProperties.getInstance();
         File trainingData = new File("test/train.data");
         assertThat(
             DeLFTModel.getTrainCommand("model1", trainingData),
@@ -28,7 +35,6 @@ public class DeLFTModelTest {
 
     @Test
     public void testShouldAddUseELMO() {
-        GrobidProperties.getInstance();
         GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_ELMO, "true");
         File trainingData = new File("test/train.data");
         assertThat(
@@ -38,6 +44,21 @@ public class DeLFTModelTest {
                 "--input", trainingData.getAbsolutePath(),
                 "--output", GrobidProperties.getModelPath().getAbsolutePath(),
                 "--use-ELMo"
+            )
+        );
+    }
+
+    @Test
+    public void testShouldAddSingleCustomArg() {
+        GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "arg1");
+        File trainingData = new File("test/train.data");
+        assertThat(
+            DeLFTModel.getTrainCommand("model1", trainingData),
+            contains(
+                "python3", "grobidTagger.py", "model1", "train",
+                "--input", trainingData.getAbsolutePath(),
+                "--output", GrobidProperties.getModelPath().getAbsolutePath(),
+                "arg1"
             )
         );
     }

--- a/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/DeLFTModelTest.java
@@ -14,9 +14,8 @@ public class DeLFTModelTest {
     @Test
     public void testShouldBuildTrainCommand() {
         File trainingData = new File("test/train.data");
-        File outputModel = new File("test/output");
         assertThat(
-            DeLFTModel.getTrainCommand("model1", trainingData, outputModel),
+            DeLFTModel.getTrainCommand("model1", trainingData),
             contains(
                 "python3", "grobidTagger.py", "model1", "train",
                 "--input", trainingData.getAbsolutePath(),

--- a/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
@@ -62,18 +62,6 @@ public class GrobidPropertiesTest {
     }
 
     @Test
-    public void testShouldReturnEmptyTrainArgsByDefault() {
-        GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS);
-        assertEquals(GrobidProperties.getDeLFTTrainArgs(), "");
-    }
-
-    @Test
-    public void testShouldReturnConfiguredTrainArgs() {
-        GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "args");
-        assertEquals(GrobidProperties.getDeLFTTrainArgs(), "args");
-    }
-
-    @Test
     public void testShouldReturnEmptyTrainModuleByDefault() {
         GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_MODULE);
         assertEquals(GrobidProperties.getDeLFTTrainModule(), "");
@@ -85,6 +73,18 @@ public class GrobidPropertiesTest {
             GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_MODULE, "module1"
         );
         assertEquals(GrobidProperties.getDeLFTTrainModule(), "module1");
+    }
+
+    @Test
+    public void testShouldReturnEmptyTrainArgsByDefault() {
+        GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS);
+        assertEquals(GrobidProperties.getDeLFTTrainArgs(), "");
+    }
+
+    @Test
+    public void testShouldReturnConfiguredTrainArgs() {
+        GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "args");
+        assertEquals(GrobidProperties.getDeLFTTrainArgs(), "args");
     }
 
     @Test(expected = GrobidPropertyException.class)

--- a/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
@@ -73,6 +73,20 @@ public class GrobidPropertiesTest {
         assertEquals(GrobidProperties.getDeLFTTrainArgs(), "args");
     }
 
+    @Test
+    public void testShouldReturnEmptyTrainModuleByDefault() {
+        GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS);
+        assertEquals(GrobidProperties.getDeLFTTrainModule(), "");
+    }
+
+    @Test
+    public void testShouldReturnConfiguredModule() {
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_MODULE, "module1"
+        );
+        assertEquals(GrobidProperties.getDeLFTTrainModule(), "module1");
+    }
+
     @Test(expected = GrobidPropertyException.class)
     public void testCheckPropertiesException_shouldThrowException() {
         GrobidProperties.getProps().put(

--- a/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
@@ -61,6 +61,18 @@ public class GrobidPropertiesTest {
                 .getNativeLibraryPath().getCanonicalFile());
     }
 
+    @Test
+    public void testShouldReturnEmptyTrainArgsByDefault() {
+        GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS);
+        assertEquals(GrobidProperties.getDeLFTTrainArgs(), "");
+    }
+
+    @Test
+    public void testShouldReturnConfiguredTrainArgs() {
+        GrobidProperties.getProps().put(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS, "args");
+        assertEquals(GrobidProperties.getDeLFTTrainArgs(), "args");
+    }
+
     @Test(expected = GrobidPropertyException.class)
     public void testCheckPropertiesException_shouldThrowException() {
         GrobidProperties.getProps().put(

--- a/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
@@ -75,7 +75,7 @@ public class GrobidPropertiesTest {
 
     @Test
     public void testShouldReturnEmptyTrainModuleByDefault() {
-        GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_ARGS);
+        GrobidProperties.getProps().remove(GrobidPropertyKeys.PROP_GROBID_DELFT_TRAIN_MODULE);
         assertEquals(GrobidProperties.getDeLFTTrainModule(), "");
     }
 


### PR DESCRIPTION
same as #469 

Allows custom args to be passed in to the the training operation.

It adds the following optional configuration options:
- `grobid.delft.train.module`: Training module (default is `grobidTagger.py` as per `DeLFTModel`)
- `grobid.delft.train.args`: additional arguments to be passed to the training module. To keep it simple, it's split on spaces (which could be improved, should shell parsing be required in the future).

This is also useful for the current training, to configure the training.

The `useELMo` flag didn't actually work for training because the `command` list was immutable.
