### PR TITLE
added support for environment variable overrides

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/EnvironmentVariableProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/EnvironmentVariableProperties.java
@@ -1,0 +1,31 @@
+package org.grobid.core.utilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnvironmentVariableProperties {
+
+    private final Map<String, String> properties = new HashMap<>();
+
+    public EnvironmentVariableProperties(String prefix) {
+        this(System.getenv(), prefix);
+    }
+
+    public EnvironmentVariableProperties(Map<String, String> environmentVariablesMap, String prefix) {
+        for (Map.Entry<String, String> entry: environmentVariablesMap.entrySet()) {
+            if (!entry.getKey().startsWith(prefix)) {
+                continue;
+            }
+            String propertiesKey = getPropertiesKeyForEnvironmentVariableName(entry.getKey());
+            this.properties.put(propertiesKey, entry.getValue());
+        }
+    }
+
+    private static String getPropertiesKeyForEnvironmentVariableName(String name) {
+        return name.replace("__", ".").toLowerCase();
+    }
+
+    public Map<String, String> getProperties() {
+        return this.properties;
+    }
+}

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.Enumeration;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -301,6 +302,8 @@ public class GrobidProperties {
             throw new GrobidPropertyException("Cannot open file of grobid properties" + getGrobidPropertiesPath().getAbsolutePath(), exp);
         }
 
+        getProps().putAll(getEnvironmentVariableOverrides(System.getenv()));
+
         initializePaths();
         //checkProperties();
         loadPdf2XMLPath();
@@ -337,6 +340,14 @@ public class GrobidProperties {
             }
         }
         return GROBID_VERSION;
+    }
+
+    protected static Map<String, String> getEnvironmentVariableOverrides(Map<String, String> environmentVariablesMap) {
+        Map<String, String> properties = new EnvironmentVariableProperties(
+            environmentVariablesMap, "GROBID__"
+        ).getProperties();
+        LOGGER.info("environment variables overrides: {}", properties);
+        return properties;
     }
 
     /**

--- a/grobid-core/src/test/java/org/grobid/core/utilities/EnvironmentVariablePropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/EnvironmentVariablePropertiesTest.java
@@ -1,0 +1,73 @@
+package org.grobid.core.utilities;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class EnvironmentVariablePropertiesTest {
+    private Map<String, String> environmentVariables = new HashMap<>();
+
+    @Test
+    public void shouldReturnEmptyPropertiesWithEmptyEnvironmentVariables() {
+        assertEquals(
+            Collections.emptyMap(),
+            new EnvironmentVariableProperties(
+                environmentVariables,
+                "APP__"
+            ).getProperties()
+        );
+    }
+
+    @Test
+    public void shouldReturnEmptyPropertiesWithNotMatchingEnvironmentVariables() {
+        environmentVariables.put("OTHER__ABC", "value1");
+        assertEquals(
+            Collections.emptyMap(),
+            new EnvironmentVariableProperties(
+                environmentVariables,
+                "APP__"
+            ).getProperties()
+        );
+    }
+
+    @Test
+    public void shouldReturnAndConvertMatchingEnvironmentVariable() {
+        environmentVariables.put("APP__ABC", "value1");
+        assertEquals(
+            Collections.singletonMap("app.abc", "value1"),
+            new EnvironmentVariableProperties(
+                environmentVariables,
+                "APP__"
+            ).getProperties()
+        );
+    }
+
+    @Test
+    public void shouldReturnAndConvertMatchingNestedEnvironmentVariable() {
+        environmentVariables.put("APP__ABC__XYZ", "value1");
+        assertEquals(
+            Collections.singletonMap("app.abc.xyz", "value1"),
+            new EnvironmentVariableProperties(
+                environmentVariables,
+                "APP__"
+            ).getProperties()
+        );
+    }
+
+    @Test
+    public void shouldReturnAndConvertMatchingEnvironmentVariableWithUnderscore() {
+        environmentVariables.put("APP__ABC_XYZ", "value1");
+        assertEquals(
+            Collections.singletonMap("app.abc_xyz", "value1"),
+            new EnvironmentVariableProperties(
+                environmentVariables,
+                "APP__"
+            ).getProperties()
+        );
+    }
+}

--- a/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -52,6 +53,16 @@ public class GrobidPropertiesTest {
     public void testLoadGrobidProperties_PathNoContext_shouldThrowException() throws Exception {
         GrobidProperties.reset();
         GrobidProperties.loadGrobidPropertiesPath();
+    }
+
+    @Test
+    public void shouldReturnAndConvertMatchingEnvironmentVariable() throws Exception {
+        assertEquals(
+            Collections.singletonMap("grobid.abc", "value1"),
+            GrobidProperties.getEnvironmentVariableOverrides(
+                Collections.singletonMap("GROBID__ABC", "value1")
+            )
+        );
     }
 
     @Test


### PR DESCRIPTION
same as #482

implementation of first option discussed in #480

For example setting `GROBID__HEADER__USE_HEURISTICS=false` results in `grobid.header.use_heuristics: false`.