### PR TITLE
include marker in raw affiliation label

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -3766,11 +3766,15 @@ public class BiblioItem {
             String encodedRawAffiliationString = TextUtilities.HTMLEncode(
                 aff.getRawAffiliationString()
             );
-            tei.append(
-                "<note type=\"raw_affiliation\">" +
-                encodedRawAffiliationString +
-                "</note>\n"
-            );
+            tei.append("<note type=\"raw_affiliation\">");
+            LOGGER.info("marker: {}", aff.getMarker());
+            if (StringUtils.isNotEmpty(aff.getMarker())) {
+                tei.append("<label>");
+                tei.append(aff.getMarker());
+                tei.append("</label> ");
+            }
+            tei.append(encodedRawAffiliationString);
+            tei.append("</note>\n");
         }
 
         if (aff.getDepartments() != null) {

--- a/grobid-core/src/test/java/org/grobid/core/data/BiblioItemTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/data/BiblioItemTest.java
@@ -88,6 +88,34 @@ public class BiblioItemTest {
     }
 
     @Test
+    public void shouldIncludeMarkerInRawAffiliationText() throws Exception {
+        GrobidAnalysisConfig config = configBuilder.includeRawAffiliations(true).build();
+        Affiliation aff = new Affiliation();
+        aff.setMarker("A");
+        aff.setRawAffiliationString("raw affiliation 1");
+        aff.setFailAffiliation(false);
+        Person author = new Person();
+        author.setLastName("Smith");
+        author.setAffiliations(Arrays.asList(aff));
+        BiblioItem biblioItem = new BiblioItem();
+        biblioItem.setFullAuthors(Arrays.asList(author));
+        biblioItem.setFullAffiliations(Arrays.asList(aff));
+        String tei = biblioItem.toTEI(0, 2, config);
+        LOGGER.debug("tei: {}", tei);
+        Document doc = parseXml(tei);
+        assertThat(
+            "raw_affiliation label",
+            getXpathStrings(doc, "//note[@type=\"raw_affiliation\"]/label/text()"),
+            is(Arrays.asList("A"))
+        );
+        assertThat(
+            "raw_affiliation",
+            getXpathStrings(doc, "//note[@type=\"raw_affiliation\"]/text()"),
+            is(Arrays.asList(" raw affiliation 1"))
+        );
+    }
+
+    @Test
     public void shouldGnerateRawAffiliationTextForFailAffiliationsIfEnabled() throws Exception {
         GrobidAnalysisConfig config = configBuilder.includeRawAffiliations(true).build();
         Affiliation aff = new Affiliation();


### PR DESCRIPTION
additionally include the marker as the `<label>` element within the raw affiliation note.