### PR TITLE
optionally remove line numbers

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -35,6 +35,7 @@ import org.grobid.core.sax.*;
 
 import org.grobid.core.utilities.BoundingBoxCalculator;
 import org.grobid.core.utilities.ElementCounter;
+import org.grobid.core.utilities.GrobidProperties;
 import org.grobid.core.utilities.LayoutTokensUtil;
 import org.grobid.core.utilities.Pair;
 import org.grobid.core.utilities.TextUtilities;
@@ -480,7 +481,9 @@ public class Document implements Serializable {
         }
 
         // we filter out possible line numbering for review works
-        // filterLineNumber();
+        if (GrobidProperties.isFeatureFlag("remove_line_numbers")) {
+            new LineNumberFilter().findAndRemoveLineNumbers(this.getBlocks());
+        }
         return tokenizations;
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/document/LineNumberFilter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/LineNumberFilter.java
@@ -1,0 +1,288 @@
+package org.grobid.core.document;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.grobid.core.layout.Block;
+import org.grobid.core.layout.LayoutToken;
+import org.grobid.core.layout.Page;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+class LineNumberFilter {
+    class LineNumberToken {
+        private Block block;
+        private LayoutToken layoutToken;
+        private int documentPosition;
+        private int lineNumber;
+
+        public LineNumberToken(
+            Block block,
+            LayoutToken layoutToken,
+            int documentPosition,
+            int lineNumber
+        ) {
+            this.block = block;
+            this.layoutToken = layoutToken;
+            this.documentPosition = documentPosition;
+            this.lineNumber = lineNumber;
+        }
+
+        public String toString() {
+            return String.format(
+                "LineNumberToken(\"%s\", documentPosition=%s, x=%f, y=%f)",
+                this.layoutToken, this.documentPosition,
+                this.layoutToken.getX(), this.layoutToken.getY()
+            );
+        }
+
+        public Block getBlock() {
+            return this.block;
+        }
+
+        public LayoutToken getLayoutToken() {
+            return this.layoutToken;
+        }
+
+        public int getDocumentPosition() {
+            return this.documentPosition;
+        }
+
+        public int getPageNumber() {
+            Page page = this.block.getPage();
+            if (page == null) {
+                return 0;
+            }
+            return page.getNumber();
+        }
+
+        public int getLineNumber() {
+            return this.lineNumber;
+        }
+    }
+
+    private Comparator<LineNumberToken> byLineNumber = (
+        LineNumberToken token1, LineNumberToken token2
+    ) -> Integer.valueOf(token1.getLineNumber()).compareTo(
+        token2.getLineNumber()
+    );
+
+    private Comparator<LineNumberToken> byPageAndLineNumber = (
+        LineNumberToken token1, LineNumberToken token2
+    ) -> (
+        token1.getPageNumber() == token2.getPageNumber()
+        ? Integer.valueOf(token1.getLineNumber()).compareTo(
+            token2.getLineNumber()
+        )
+        : Integer.valueOf(token1.getPageNumber()).compareTo(
+            token2.getPageNumber()
+        )
+    );
+
+    public static final Logger logger = LoggerFactory.getLogger(LineNumberFilter.class);
+
+    private static Pattern lineNumberPattern = Pattern.compile("\\d+");
+
+    private int minLineNumbers = 10;
+    private double minLineNumberRatioSimilarX = 0.8;
+
+    public void setMinLineNumbers(int minLineNumbers) {
+        this.minLineNumbers = minLineNumbers;
+    }
+
+    private List<LineNumberToken> getLineNumberTokenCandidates(List<Block> blocks) {
+        List<LineNumberToken> lineNumberTokens = new ArrayList<>();
+        if (blocks == null) {
+            return lineNumberTokens;
+        }
+        int documentPosition = 1;
+        for (Block block: blocks) {
+            List<LayoutToken> tokens = block.getTokens();
+            LayoutToken previousBlockToken = null;
+            for (LayoutToken token: tokens) {
+                boolean newLine = (
+                    (previousBlockToken == null)
+                    || (
+                        (previousBlockToken.getY() < token.getY())
+                        && (previousBlockToken.getX() >= token.getX())
+                    )
+                );
+                if (!newLine) {
+                    continue;
+                }
+                String tokenText = token.getText();
+                Matcher lineNumberMatcher = lineNumberPattern.matcher(tokenText);
+                if (lineNumberMatcher.matches()) {
+                    int lineNumber = Integer.parseInt(tokenText);
+                    LineNumberToken lineNumberToken = new LineNumberToken(
+                        block, token, documentPosition++, lineNumber
+                    );
+                    logger.debug(
+                        "adding lineNumberToken candidate: {}, newline: {}",
+                        lineNumberToken, newLine
+                    );
+                    lineNumberTokens.add(lineNumberToken);
+                }
+                previousBlockToken = token;
+            }
+        }
+        return lineNumberTokens;
+    }
+
+    private double getMedian(List<Double> list) {
+        List<Double> sorted = new ArrayList<>(list);
+        Collections.sort(sorted);
+        int medianIndex = list.size() / 2;
+        if (list.size() % 2 == 0) {
+            return (sorted.get(medianIndex) + sorted.get(medianIndex + 1)) / 2.0;
+        }
+        return sorted.get(medianIndex);
+    }
+
+    private double getMedianTokenX(List<LineNumberToken> tokens) {
+        return getMedian(tokens.stream().map(
+            (LineNumberToken token) -> token.getLayoutToken().getX()
+        ).collect(Collectors.toList()));
+    }
+
+    private double getMedianTokenWidth(List<LineNumberToken> tokens) {
+        return getMedian(tokens.stream().map(
+            (LineNumberToken token) -> token.getLayoutToken().getWidth()
+        ).collect(Collectors.toList()));
+    }
+
+    private List<LineNumberToken> filterLineNumberTokensWithXBetween(
+        List<LineNumberToken> tokens,
+        double minX,
+        double maxX
+    ) {
+        return (
+            tokens
+            .stream()
+            .filter((LineNumberToken token) -> (
+                token.getLayoutToken().getX() >= minX
+                && token.getLayoutToken().getX() <= maxX
+            )).collect(Collectors.toList())
+        );
+    }
+
+    private long countTokensWithXBetween(
+        List<Block> blocks,
+        double minX,
+        double maxX
+    ) {
+        return (
+            blocks
+            .stream()
+            .flatMap((Block block) -> block.getTokens().stream())
+            .filter((LayoutToken token) -> (
+                token.getX() >= minX
+                && token.getX() <= maxX
+            )).collect(Collectors.counting())
+        );
+    }
+
+    public List<LineNumberToken> getLineNumberTokens(List<Block> blocks) {
+        List<LineNumberToken> lineNumberTokensCandidates = (
+            this.getLineNumberTokenCandidates(blocks)
+        );
+        if (lineNumberTokensCandidates.size() < this.minLineNumbers) {
+            return Collections.emptyList();
+        }
+        double medianTokenX = this.getMedianTokenX(lineNumberTokensCandidates);
+        double medianTokenWidth = this.getMedianTokenWidth(lineNumberTokensCandidates);
+        lineNumberTokensCandidates = this.filterLineNumberTokensWithXBetween(
+            lineNumberTokensCandidates,
+            medianTokenX - medianTokenWidth,
+            medianTokenX + medianTokenWidth
+        );
+        long totalNumberOfTokensOverlappingLineNumbers = this.countTokensWithXBetween(
+            blocks,
+            medianTokenX - medianTokenWidth,
+            medianTokenX + medianTokenWidth
+        );
+        logger.debug(
+            "median x={}, width={}, remaining tokens={}, total tokens with similar x={}",
+            medianTokenX, medianTokenWidth,
+            lineNumberTokensCandidates.size(),
+            totalNumberOfTokensOverlappingLineNumbers
+        );
+        Collections.sort(lineNumberTokensCandidates, this.byPageAndLineNumber);
+        List<LineNumberToken> lineNumberTokens = new ArrayList<>(
+            lineNumberTokensCandidates.size()
+        );
+        LineNumberToken previousToken = null;
+        for (int i = 0; i < lineNumberTokensCandidates.size(); i++) {
+            LineNumberToken currentToken = lineNumberTokensCandidates.get(i);
+            if (previousToken == null || (
+                (
+                    previousToken.getPageNumber() < currentToken.getPageNumber()
+                    || previousToken.getLineNumber() < currentToken.getLineNumber()
+                )
+                && previousToken.getDocumentPosition() < currentToken.getDocumentPosition()
+            )) {
+                logger.debug(
+                    "adding lineNumberToken: {}, previous: {}",
+                    currentToken, previousToken
+                );
+                lineNumberTokens.add(currentToken);
+                previousToken = currentToken;
+            }
+        }
+        double lineNumberRatio = (
+            1.0 * lineNumberTokens.size() / totalNumberOfTokensOverlappingLineNumbers
+        );
+        logger.debug(
+            "potential line numbers: {}, lineNumberRatio: {}",
+            lineNumberTokens.size(),
+            lineNumberRatio
+        );
+        if (
+            lineNumberTokens.size() < this.minLineNumbers
+            || lineNumberRatio < this.minLineNumberRatioSimilarX
+        ) {
+            return Collections.emptyList();
+        }
+        return lineNumberTokens;
+    }
+
+    public List<LayoutToken> getLineNumberLayoutTokens(List<Block> blocks) {
+        List<LineNumberToken> lineNumberTokens = this.getLineNumberTokens(blocks);
+        List<LayoutToken> tokens = new ArrayList<>(lineNumberTokens.size());
+        for (LineNumberToken lineNumberToken: lineNumberTokens) {
+            tokens.add(lineNumberToken.getLayoutToken());
+        }
+        return tokens;
+    }
+
+    public void removeTokenFromBlock(Block block, LayoutToken token) {
+        List<LayoutToken> blockTokens = new ArrayList<>(block.getTokens());
+        block.resetTokens();
+        for (LayoutToken blockToken: blockTokens) {
+            if (blockToken == token) {
+                continue;
+            }
+            block.addToken(blockToken);
+        }
+    }
+
+    public void removeLineNumberTokens(List<LineNumberToken> lineNumberTokens) {
+        for (LineNumberToken lineNumberToken: lineNumberTokens) {
+            this.removeTokenFromBlock(
+                lineNumberToken.getBlock(),
+                lineNumberToken.getLayoutToken()
+            );
+        }
+    }
+
+    public void findAndRemoveLineNumbers(List<Block> blocks) {
+        List<LineNumberToken> lineNumberTokens = this.getLineNumberTokens(blocks);
+        removeLineNumberTokens(lineNumberTokens);
+    }
+}

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -796,6 +796,13 @@ public class GrobidProperties {
         return theFile;
     }
 
+    public static Boolean isFeatureFlag(String featureName) {
+        return Utilities.stringToBoolean(getPropertyValue(
+            GrobidPropertyKeys.PROP_FEATURE_FLAG_PREFIX + featureName,
+            "false"
+        ));
+    }
+
     public static String getLexiconPath() {
         return new File(get_GROBID_HOME_PATH(), "lexicon").getAbsolutePath();
     }

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
@@ -29,6 +29,8 @@ public interface GrobidPropertyKeys {
     String PROP_HEADER_USE_HEURISTICS = "grobid.header.use_heuristics";
     String PROP_HEADER_USE_LABELED_ABSTRACT = "grobid.header.use_labeled_abstract";
 
+    String PROP_FEATURE_FLAG_PREFIX = "grobid.features.";
+
     String PROP_CROSSREF_ID = "grobid.crossref_id";
     String PROP_CROSSREF_PW = "grobid.crossref_pw";
     String PROP_CROSSREF_HOST = "grobid.crossref_host";

--- a/grobid-core/src/test/java/org/grobid/core/document/LineNumberFilterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/LineNumberFilterTest.java
@@ -1,0 +1,192 @@
+package org.grobid.core.document;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.collections4.ListUtils;
+import org.grobid.core.layout.Block;
+import org.grobid.core.layout.LayoutToken;
+import org.grobid.core.layout.Page;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class LineNumberFilterTest {
+    public static final Logger logger = LoggerFactory.getLogger(LineNumberFilterTest.class);
+
+    private LineNumberFilter filter = new LineNumberFilter();
+
+    private double lineHeight = 10.0;
+    private double tokenWidth = 10.0;
+
+    public LineNumberFilterTest() {
+    }
+
+    private List<LayoutToken> getLineNumberLayoutTokens(List<Block> blocks) {
+        List<LayoutToken> actualLineNumberTokens = this.filter.getLineNumberLayoutTokens(blocks);
+        logger.debug("line number tokens: {}", actualLineNumberTokens);
+        return actualLineNumberTokens;
+    }
+
+    private LayoutToken createLayoutToken(
+        String text,
+        double x,
+        double y
+    ) {
+        LayoutToken token = new LayoutToken(text);
+        token.setX(x);
+        token.setY(y);
+        token.setWidth(this.lineHeight);
+        token.setHeight(this.tokenWidth);
+        return token;
+    }
+
+    private List<LayoutToken> createLineNumberTokens(
+        int start,
+        int count,
+        double x,
+        double startY
+    ) {
+        List<LayoutToken> tokens = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            tokens.add(createLayoutToken(
+                String.valueOf(start + i),
+                x,
+                startY + (i + this.lineHeight)
+            ));
+        }
+        return tokens;
+    }
+
+    private Block createBlock(List<LayoutToken> tokens) {
+        Block block = new Block();
+        for (LayoutToken token: tokens) {
+            block.addToken(token);
+        }
+        return block;
+    }
+
+    @Test
+    public void shouldNotFailOnNullBlocks() {
+        this.filter.getLineNumberLayoutTokens(null);
+    }
+
+    @Test
+    public void shouldMatchLeftLineNumbers() {
+        List<LayoutToken> lineNumberTokens = this.createLineNumberTokens(
+            1, 10, 10.0, 10.0
+        );
+        Block block = createBlock(lineNumberTokens);
+        assertThat(
+            "lineNumberTokens",
+            this.filter.getLineNumberLayoutTokens(Arrays.asList(block)),
+            is(lineNumberTokens)
+        );
+    }
+
+    @Test
+    public void shouldOnlyMatchContineousLineNumbersOnTheLeft() {
+        List<LayoutToken> lineNumberTokens = this.createLineNumberTokens(
+            1, 10, 10.0, 10.0
+        );
+        LayoutToken otherSameLineNumberToken = createLayoutToken("2", 20.0, 10.0);
+        Block block = createBlock(Arrays.asList(
+            lineNumberTokens.get(0),
+            otherSameLineNumberToken
+        ));
+        for (LayoutToken token: lineNumberTokens.subList(1, lineNumberTokens.size())) {
+            block.addToken(token);
+        }
+        assertThat(
+            "lineNumberTokens",
+            this.getLineNumberLayoutTokens(Arrays.asList(block)),
+            is(lineNumberTokens)
+        );
+    }
+
+    @Test
+    public void shouldNotMatchLineNumbersInReverseOrder() {
+        List<LayoutToken> lineNumberTokens = this.createLineNumberTokens(
+            1, 10, 10.0, 10.0
+        );
+        // make the numbers go from 10 to 1 instead
+        for (int i = 0; i < lineNumberTokens.size(); i++) {
+            lineNumberTokens.get(i).setText(String.valueOf(
+                lineNumberTokens.size() - i
+            ));
+        }
+        Block block = createBlock(lineNumberTokens);
+        assertThat(
+            "lineNumberTokens",
+            this.getLineNumberLayoutTokens(Arrays.asList(block)),
+            empty()
+        );
+    }
+
+    @Test
+    public void shouldNotMatchNumbersOnADifferentXAxis() {
+        List<LayoutToken> lineNumberTokens = this.createLineNumberTokens(
+            1, 10, 10.0, 10.0
+        );
+        List<LayoutToken> otherTokens = this.createLineNumberTokens(
+            11, 5, 100.0, 100.0 + 10 * this.lineHeight
+        );
+        Block block = createBlock(ListUtils.union(
+            lineNumberTokens,
+            otherTokens
+        ));
+        assertThat(
+            "lineNumberTokens",
+            this.getLineNumberLayoutTokens(Arrays.asList(block)),
+            is(lineNumberTokens)
+        );
+    }
+
+    @Test
+    public void shouldNotMatchLineNumbersMixedWithOtherTokens() {
+        List<LayoutToken> lineNumberTokens = this.createLineNumberTokens(
+            1, 10, 10.0, 10.0
+        );
+        List<LayoutToken> otherTokens = this.createLineNumberTokens(
+            1, 10, 10.0, 10.0 + 10 * this.lineHeight
+        );
+        // change the text to "other" to not match line number pattern anymore
+        for (LayoutToken otherToken: otherTokens) {
+            otherToken.setText("other");
+        }
+        Block block = createBlock(ListUtils.union(
+            lineNumberTokens,
+            otherTokens
+        ));
+        assertThat(
+            "lineNumberTokens",
+            this.getLineNumberLayoutTokens(Arrays.asList(block)),
+            empty()
+        );
+    }
+
+    @Test
+    public void shouldAllowResetOfLineNumbersPerPage() {
+        List<LayoutToken> pageOneLineNumberTokens = this.createLineNumberTokens(
+            1, 10, 10.0, 10.0
+        );
+        List<LayoutToken> pageTwoLineNumberTokens = this.createLineNumberTokens(
+            1, 10, 10.0, 10.0
+        );
+        Block pageOneBlock = createBlock(pageOneLineNumberTokens);
+        pageOneBlock.setPage(new Page(1));
+        Block pageTwoBlock = createBlock(pageTwoLineNumberTokens);
+        pageTwoBlock.setPage(new Page(2));
+        assertThat(
+            "lineNumberTokens",
+            this.getLineNumberLayoutTokens(Arrays.asList(pageOneBlock, pageTwoBlock)),
+            is(ListUtils.union(pageOneLineNumberTokens, pageTwoLineNumberTokens))
+        );
+    }
+}


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5515

This tries to handle line numbers as an interim solution. It doesn't attempt to cover all case (e.g. right side line numbers do not seem to happen in our dataset and are not handled).

This feature can be enabled via the property:
`grobid.features.remove_line_numbers = true`

Run related tests:

```bash
./gradlew -t grobid-core:test -no-daemon --info --tests org.grobid.core.document.LineNumberFilterTest
```