### PR TITLE
improved line number detection

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -441,6 +441,15 @@ public class Document implements Serializable {
             throw new GrobidException("PDF parsing resulted in empty content", GrobidExceptionStatus.NO_BLOCKS);
         }
 
+        // we filter out possible line numbering for review works
+        if (GrobidProperties.isFeatureFlag("remove_line_numbers")) {
+            LineNumberFilter lineNumberFilter = new LineNumberFilter();
+            lineNumberFilter.findAndRemoveLineNumbers(this.getBlocks());
+            tokenizations = lineNumberFilter.recalculateDocumentTokenization(
+                this.getBlocks()
+            );
+        }
+
         // calculating main area
         calculatePageMainAreas();
 
@@ -480,10 +489,6 @@ public class Document implements Serializable {
             }
         }
 
-        // we filter out possible line numbering for review works
-        if (GrobidProperties.isFeatureFlag("remove_line_numbers")) {
-            new LineNumberFilter().findAndRemoveLineNumbers(this.getBlocks());
-        }
         return tokenizations;
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/document/LineNumberFilter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/LineNumberFilter.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 
 class LineNumberFilter {
-    class LineNumberToken {
+    static class LineNumberToken {
         private Block block;
         private LayoutToken layoutToken;
         private int documentPosition;
@@ -270,11 +270,17 @@ class LineNumberFilter {
     public void removeTokenFromBlock(Block block, LayoutToken token) {
         List<LayoutToken> blockTokens = new ArrayList<>(block.getTokens());
         block.resetTokens();
+        boolean removeNextSpace = false;
         for (LayoutToken blockToken: blockTokens) {
             if (blockToken == token) {
+                removeNextSpace = true;
+                continue;
+            }
+            if (removeNextSpace && blockToken.getText().equals(" ")) {
                 continue;
             }
             block.addToken(blockToken);
+            removeNextSpace = false;
         }
     }
 

--- a/grobid-core/src/test/java/org/grobid/core/document/LineNumberFilterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/LineNumberFilterTest.java
@@ -206,4 +206,32 @@ public class LineNumberFilterTest {
             is(ListUtils.union(pageOneLineNumberTokens, pageTwoLineNumberTokens))
         );
     }
+
+    @Test
+    public void shouldUpdateBlockTextWhenRemovingLineNumbers() {
+        LayoutToken lineNumberToken = createLayoutToken("1", 10, 10);
+        LayoutToken spaceToken = createLayoutToken(" ", 20, 10);
+        List<LayoutToken> otherTokens = Arrays.asList(
+            createLayoutToken("other", 30, 10),
+            createLayoutToken(" ", 40, 10),
+            createLayoutToken("text", 50, 10)
+        );
+        Block block = createBlock(ListUtils.union(
+            ListUtils.union(
+                Arrays.asList(lineNumberToken),
+                Arrays.asList(spaceToken)
+            ),
+            otherTokens
+        ));
+        block.setPage(new Page(1));
+        block.setText("1 other text");
+        assertThat("block.text (before)", block.getText(), is("1 other text"));
+        this.filter.removeLineNumberTokens(Arrays.asList(new LineNumberFilter.LineNumberToken(
+            block,
+            lineNumberToken,
+            1,
+            1
+        )));
+        assertThat("block.text (after)", block.getText(), is("other text"));
+    }
 }

--- a/grobid-core/src/test/java/org/grobid/core/document/LineNumberFilterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/LineNumberFilterTest.java
@@ -226,12 +226,15 @@ public class LineNumberFilterTest {
         block.setPage(new Page(1));
         block.setText("1 other text");
         assertThat("block.text (before)", block.getText(), is("1 other text"));
-        this.filter.removeLineNumberTokens(Arrays.asList(new LineNumberFilter.LineNumberToken(
-            block,
-            lineNumberToken,
-            1,
-            1
-        )));
+        this.filter.removeLineNumberTokens(
+            Arrays.asList(block),
+            Arrays.asList(new LineNumberFilter.LineNumberToken(
+                block,
+                lineNumberToken,
+                1,
+                1
+            ))
+        );
         assertThat("block.text (after)", block.getText(), is("other text"));
     }
 }


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5527

extension of #19 

Some line numbers were not detected, usually at the beginning of a page or when the token order doesn't match the horizontal order.
This now also removes the line numbers from the document tokens (not just blocks).