### PR TITLE
fixed reset start and end token of empty blocks after removing line numbers

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/LineNumberFilter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/LineNumberFilter.java
@@ -311,10 +311,11 @@ class LineNumberFilter {
             List<Block> blocks) {
         List<LayoutToken> tokenization = new ArrayList<>();
         for (Block block: blocks) {
+            block.setStartToken(tokenization.size());
             if (block.getTokens() == null) {
+                block.setEndToken(tokenization.size());
                 continue;
             }
-            block.setStartToken(tokenization.size());
             block.setEndToken(tokenization.size() + block.getTokens().size());
             tokenization.addAll(block.getTokens());
         }

--- a/grobid-core/src/test/java/org/grobid/core/document/LineNumberFilterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/LineNumberFilterTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.empty;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.collections4.ListUtils;
@@ -236,5 +237,41 @@ public class LineNumberFilterTest {
             ))
         );
         assertThat("block.text (after)", block.getText(), is("other text"));
+    }
+
+    @Test
+    public void shouldResetStartAndEndBlockOfNonEmptyAndEmptyBlocks() {
+        Block nonEmptyBlock = createBlock(Arrays.asList(
+            createLayoutToken("token", 5, 5)
+        ));
+        nonEmptyBlock.setStartToken(100);
+        nonEmptyBlock.setEndToken(200);
+        Block emptyBlock = createBlock(Collections.emptyList());
+        emptyBlock.setStartToken(100);
+        emptyBlock.setEndToken(200);
+        List<LayoutToken> tokens = this.filter.recalculateDocumentTokenization(Arrays.asList(
+            nonEmptyBlock, emptyBlock
+        ));
+        assertThat("tokens", tokens, is(nonEmptyBlock.getTokens()));
+        assertThat(
+            "nonEmptyBlock.startToken",
+            nonEmptyBlock.getStartToken(),
+            is(0)
+        );
+        assertThat(
+            "nonEmptyBlock.endToken",
+            nonEmptyBlock.getEndToken(),
+            is(nonEmptyBlock.getTokens().size())
+        );
+        assertThat(
+            "emptyBlock.startToken",
+            emptyBlock.getStartToken(),
+            is(nonEmptyBlock.getEndToken())
+        );
+        assertThat(
+            "emptyBlock.endToken",
+            emptyBlock.getEndToken(),
+            is(nonEmptyBlock.getEndToken())
+        );
     }
 }


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5515

extension of #19

This will fix error when trying to generate training data:

```
org.grobid.core.exceptions.GrobidException: [GENERAL] An exception occurred while running Grobid training data generation for full text.
	at org.grobid.core.engines.FullTextParser.createTraining(FullTextParser.java:1467)
	at org.grobid.core.engines.Engine.createTraining(Engine.java:464)
	at org.grobid.core.engines.Engine.batchCreateTraining(Engine.java:544)
	at org.grobid.core.engines.ProcessEngine.createTraining(ProcessEngine.java:379)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.grobid.core.utilities.Utilities.launchMethod(Utilities.java:409)
	at org.grobid.core.main.batch.GrobidMain.main(GrobidMain.java:184)
Caused by: java.lang.IndexOutOfBoundsException: Index: 23624, Size: 22658
	at java.util.ArrayList.rangeCheck(ArrayList.java:657)
	at java.util.ArrayList.get(ArrayList.java:433)
	at org.grobid.core.document.Document.getTokenizationsFulltext(Document.java:290)
	at org.grobid.core.engines.FullTextParser.createTraining(FullTextParser.java:1023)
	... 9 more
```