### PR TITLE
fixed merge: pass in model to get grobid crf engine

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/engines/tagging/TaggerFactory.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/tagging/TaggerFactory.java
@@ -25,7 +25,7 @@ public class TaggerFactory {
     private TaggerFactory() {}
 
     public static synchronized GenericTagger getTagger(GrobidModel model) {
-        return getTagger(model, GrobidProperties.getGrobidCRFEngine());
+        return getTagger(model, GrobidProperties.getGrobidCRFEngine(model));
     }
 
     public static synchronized GenericTagger getTagger(GrobidModel model, GrobidCRFEngine engine) {


### PR DESCRIPTION
This would have caused the following issue for delft models:

```
GrobidException: [GENERAL] Model file does not exists or a directory: /opt/grobid/grobid-home/models/header/model.delft
```