### PR TITLE
optionally add whole line segmentation feature

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/engines/Segmentation.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/Segmentation.java
@@ -69,6 +69,8 @@ public class Segmentation extends AbstractParser {
     // projection scale for line length
     private static final int LINESCALE = 10;
 
+    public static final String WHOLE_LINE_FEATURE_FEATURE_FLAG = "segmentation_whole_line_feature";
+
     private LanguageUtilities languageUtilities = LanguageUtilities.getInstance();
     private FeatureFactory featureFactory = FeatureFactory.getInstance();
 
@@ -308,6 +310,10 @@ public class Segmentation extends AbstractParser {
         FeaturesVectorSegmentation features;
         FeaturesVectorSegmentation previousFeatures = null;
 
+        boolean wholeLineFeatureEnabled = GrobidProperties.isFeatureFlag(
+            WHOLE_LINE_FEATURE_FEATURE_FLAG
+        );
+
         for (Page page : doc.getPages()) {
             pageHeight = page.getHeight();
             newPage = true;
@@ -414,6 +420,7 @@ public class Segmentation extends AbstractParser {
                     features = new FeaturesVectorSegmentation();
                     features.token = token;
                     features.line = line;
+                    features.wholeLineFeatureEnabled = wholeLineFeatureEnabled;
 
                     if ( (blockIndex < 2) || (blockIndex > page.getBlocks().size()-2)) {
                         String pattern = featureFactory.getPattern(line);

--- a/grobid-core/src/main/java/org/grobid/core/features/FeaturesVectorSegmentation.java
+++ b/grobid-core/src/main/java/org/grobid/core/features/FeaturesVectorSegmentation.java
@@ -58,7 +58,7 @@ public class FeaturesVectorSegmentation {
     public boolean wholeLineFeatureEnabled = false; // if true, adds a feature with the whole line at the end
 
     public static String formatFeatureText(String text) {
-        return text.stripTrailing().replaceAll(" |\t", NBSP);
+        return text.strip().replaceAll(" |\t", NBSP);
     }
 
     public String printVector() {

--- a/grobid-core/src/main/java/org/grobid/core/features/FeaturesVectorSegmentation.java
+++ b/grobid-core/src/main/java/org/grobid/core/features/FeaturesVectorSegmentation.java
@@ -9,6 +9,8 @@ import org.grobid.core.utilities.TextUtilities;
  * @author Patrice Lopez
  */
 public class FeaturesVectorSegmentation {
+    public static final String NBSP = "\u00A0";
+
     public LayoutToken token = null; // not a feature, reference value
 	public String line = null; // not a feature, the complete processed line
 	
@@ -52,6 +54,12 @@ public class FeaturesVectorSegmentation {
     
     public int spacingWithPreviousBlock = 0; // discretized 
     public int characterDensity = 0; // discretized 
+
+    public boolean wholeLineFeatureEnabled = false; // if true, adds a feature with the whole line at the end
+
+    public static String formatFeatureText(String text) {
+        return text.stripTrailing().replaceAll(" |\t", NBSP);
+    }
 
     public String printVector() {
         if (string == null) return null;
@@ -235,6 +243,10 @@ public class FeaturesVectorSegmentation {
               res.append(" 0\n");
           */
 
+        if (this.wholeLineFeatureEnabled) {
+            res.append(" ");
+            res.append(formatFeatureText(this.line));
+        }
         res.append("\n");
 
         return res.toString();

--- a/grobid-core/src/main/java/org/grobid/core/features/FeaturesVectorSegmentation.java
+++ b/grobid-core/src/main/java/org/grobid/core/features/FeaturesVectorSegmentation.java
@@ -58,7 +58,7 @@ public class FeaturesVectorSegmentation {
     public boolean wholeLineFeatureEnabled = false; // if true, adds a feature with the whole line at the end
 
     public static String formatFeatureText(String text) {
-        return text.strip().replaceAll(" |\t", NBSP);
+        return text.trim().replaceAll(" |\t", NBSP);
     }
 
     public String printVector() {

--- a/grobid-core/src/test/java/org/grobid/core/engines/SegmentationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/SegmentationTest.java
@@ -78,7 +78,7 @@ public class SegmentationTest {
             String[] splittedOutput = output.split("\n");
 
             assertThat(splittedOutput[1], startsWith("Bill"));
-            String[] featuresVector = splittedOutput[1].stripTrailing().split(" ");
+            String[] featuresVector = splittedOutput[1].strip().split(" ");
             String lastVectorString = featuresVector[featuresVector.length - 1];
             String line = "Bill, Jim, and Scott were at a convention together and were";
             assertThat(

--- a/grobid-core/src/test/java/org/grobid/core/engines/SegmentationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/SegmentationTest.java
@@ -78,7 +78,7 @@ public class SegmentationTest {
             String[] splittedOutput = output.split("\n");
 
             assertThat(splittedOutput[1], startsWith("Bill"));
-            String[] featuresVector = splittedOutput[1].strip().split(" ");
+            String[] featuresVector = splittedOutput[1].trim().split(" ");
             String lastVectorString = featuresVector[featuresVector.length - 1];
             String line = "Bill, Jim, and Scott were at a convention together and were";
             assertThat(

--- a/grobid-core/src/test/java/org/grobid/core/engines/SegmentationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/SegmentationTest.java
@@ -4,6 +4,9 @@ import org.grobid.core.document.Document;
 import org.grobid.core.document.DocumentSource;
 import org.grobid.core.engines.config.GrobidAnalysisConfig;
 import org.grobid.core.factory.AbstractEngineFactory;
+import org.grobid.core.features.FeaturesVectorSegmentation;
+import org.grobid.core.utilities.GrobidProperties;
+import org.grobid.core.utilities.GrobidPropertyKeys;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -35,6 +38,10 @@ public class SegmentationTest {
     @Before
     public void setUp() throws Exception {
         target = new Segmentation();
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_FEATURE_FLAG_PREFIX + Segmentation.WHOLE_LINE_FEATURE_FEATURE_FLAG,
+            "false"
+        );
     }
 
     @Test
@@ -53,6 +60,35 @@ public class SegmentationTest {
         assertThat(splittedOutput[0], is("Title Title title T Ti Tit Titl BLOCKSTART PAGESTART NEWFONT HIGHERFONT 1 0 INITCAP NODIGIT 0 0 1 0 0 0 0 0 12 12 no 0 10 0 0 0 0 1"));
 		
 		doc.close(true, true, true);
+    }
+
+    @Test
+    public void test_GetAllLinesFeatures_shouldAddWholeLineFeatureIfEnabled() throws Exception {
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_FEATURE_FLAG_PREFIX + Segmentation.WHOLE_LINE_FEATURE_FEATURE_FLAG,
+            "true"
+        );
+        File input = new File(this.getClass().getResource("samplePdf.segmentation.pdf").toURI());
+        DocumentSource doc = DocumentSource.fromPdf(input);
+        try {
+            final Document document = new Document(doc);
+            document.addTokenizedDocument(GrobidAnalysisConfig.defaultInstance());
+            String output = target.getAllLinesFeatured(document);
+
+            String[] splittedOutput = output.split("\n");
+
+            assertThat(splittedOutput[1], startsWith("Bill"));
+            String[] featuresVector = splittedOutput[1].stripTrailing().split(" ");
+            String lastVectorString = featuresVector[featuresVector.length - 1];
+            String line = "Bill, Jim, and Scott were at a convention together and were";
+            assertThat(
+                "last feature value",
+                lastVectorString,
+                is(FeaturesVectorSegmentation.formatFeatureText(line))
+            );
+        } finally {
+            doc.close(true, true, true);
+        }
     }
 
     @Test

--- a/grobid-core/src/test/java/org/grobid/core/features/FeaturesVectorSegmentationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/features/FeaturesVectorSegmentationTest.java
@@ -48,7 +48,7 @@ public class FeaturesVectorSegmentationTest {
     @Test
     public void shouldNotAddWholeLineFeatureIfEnabled() {
         this.features.wholeLineFeatureEnabled = false;
-        String[] featuresVector = features.printVector().strip().split(" ");
+        String[] featuresVector = features.printVector().trim().split(" ");
         String lastVectorString = featuresVector[featuresVector.length - 1];
         assertThat(
             "last feature",

--- a/grobid-core/src/test/java/org/grobid/core/features/FeaturesVectorSegmentationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/features/FeaturesVectorSegmentationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -59,7 +60,7 @@ public class FeaturesVectorSegmentationTest {
     @Test
     public void shouldAddWholeLineFeatureIfEnabled() {
         this.features.wholeLineFeatureEnabled = true;
-        String[] featuresVector = features.printVector().strip().split(" ");
+        String[] featuresVector = features.printVector().trim().split(" ");
         String lastVectorString = featuresVector[featuresVector.length - 1];
         assertThat(
             "last feature",

--- a/grobid-core/src/test/java/org/grobid/core/features/FeaturesVectorSegmentationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/features/FeaturesVectorSegmentationTest.java
@@ -1,0 +1,70 @@
+package org.grobid.core.features;
+
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+
+
+public class FeaturesVectorSegmentationTest {
+
+    private FeaturesVectorSegmentation features = new FeaturesVectorSegmentation();
+
+    public FeaturesVectorSegmentationTest() {
+        this.features.line = "this is the whole line";
+        this.features.string = "this";
+        this.features.secondString = "is";
+        this.features.digit = "";
+    }
+
+    @Test
+    public void test_formatFeatureText_shouldReplaceSpaceWithNonBreakingSpace() {
+        List<String> tokens = Arrays.asList("token1", "token2", "token3");
+        String line = String.join(" ", tokens);
+        assertThat(
+            "formatted feature text",
+            FeaturesVectorSegmentation.formatFeatureText(line),
+            is(String.join(FeaturesVectorSegmentation.NBSP, tokens))
+        );
+    }
+
+    @Test
+    public void test_formatFeatureText_shouldReplaceTabsWithNonBreakingSpace() {
+        List<String> tokens = Arrays.asList("token1", "token2", "token3");
+        String line = String.join("\t", tokens);
+        assertThat(
+            "formatted feature text",
+            FeaturesVectorSegmentation.formatFeatureText(line),
+            is(String.join(FeaturesVectorSegmentation.NBSP, tokens))
+        );
+    }
+
+    @Test
+    public void shouldNotAddWholeLineFeatureIfEnabled() {
+        this.features.wholeLineFeatureEnabled = false;
+        String[] featuresVector = features.printVector().stripTrailing().split(" ");
+        String lastVectorString = featuresVector[featuresVector.length - 1];
+        assertThat(
+            "last feature",
+            lastVectorString,
+            is(not(FeaturesVectorSegmentation.formatFeatureText(features.line)))
+        );
+    }
+
+    @Test
+    public void shouldAddWholeLineFeatureIfEnabled() {
+        this.features.wholeLineFeatureEnabled = true;
+        String[] featuresVector = features.printVector().stripTrailing().split(" ");
+        String lastVectorString = featuresVector[featuresVector.length - 1];
+        assertThat(
+            "last feature",
+            lastVectorString,
+            is(FeaturesVectorSegmentation.formatFeatureText(features.line))
+        );
+    }
+}

--- a/grobid-core/src/test/java/org/grobid/core/features/FeaturesVectorSegmentationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/features/FeaturesVectorSegmentationTest.java
@@ -47,7 +47,7 @@ public class FeaturesVectorSegmentationTest {
     @Test
     public void shouldNotAddWholeLineFeatureIfEnabled() {
         this.features.wholeLineFeatureEnabled = false;
-        String[] featuresVector = features.printVector().stripTrailing().split(" ");
+        String[] featuresVector = features.printVector().strip().split(" ");
         String lastVectorString = featuresVector[featuresVector.length - 1];
         assertThat(
             "last feature",
@@ -59,7 +59,7 @@ public class FeaturesVectorSegmentationTest {
     @Test
     public void shouldAddWholeLineFeatureIfEnabled() {
         this.features.wholeLineFeatureEnabled = true;
-        String[] featuresVector = features.printVector().stripTrailing().split(" ");
+        String[] featuresVector = features.printVector().strip().split(" ");
         String lastVectorString = featuresVector[featuresVector.length - 1];
         assertThat(
             "last feature",


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5896

expose the whole line as a feature to allow all or more than two of the tokens be used by delft.

Spaces and tabs will be replaced with non-breaking spaces (so that they are not considered feature separators).

This feature can be enabled by setting `grobid.features.segmentation_whole_line_feature` ( `GROBID__FEATURES__SEGMENTATION_WHOLE_LINE_FEATURE`) to `true`.