### PR TITLE
fixed merge: NPE due to null delft architecture

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -119,8 +119,8 @@ public class DeLFTModel {
                 // load and tag
                 this.setJepStringValueWithFileFallback(jep, "input", this.data);
                 Boolean useFeatures = (
-                    (architecture.indexOf("FEATURE") != -1)
-                    | jep.getValue(
+                    (architecture != null && architecture.indexOf("FEATURE") != -1)
+                    || jep.getValue(
                         "getattr(" + this.modelName + ".model_config, 'use_features', False)",
                         Boolean.class
                     )


### PR DESCRIPTION
after merging upstream master, it was failing at runtime due to `architecture` being `null`.