### PR TITLE
disabled feature block distance rules

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -1281,7 +1281,15 @@ public class Document implements Serializable {
                     BoundingBox prevBlock = BoundingBox.fromPointAndDimensions(figBlock.getPageNumber(), figBlock.getX(), figBlock.getY(), figBlock.getWidth(), figBlock.getHeight());
                     blockPtr = it.next();
                     Block b = getBlocks().get(blockPtr);
-                    if (BoundingBox.fromPointAndDimensions(b.getPageNumber(), b.getX(), b.getY(), b.getWidth(), b.getHeight()).distanceTo(prevBlock) < 15) {
+                    double distanceToPreviousBlock = (
+                        BoundingBox.fromPointAndDimensions(
+                            b.getPageNumber(), b.getX(), b.getY(), b.getWidth(), b.getHeight()
+                        ).distanceTo(prevBlock)
+                    );
+                    if (
+                        GrobidProperties.isFeatureFlag("no_figure_distance_rules")
+                        | distanceToPreviousBlock < 15
+                    ) {
                         result.addAll(b.getTokens());
                         figBlock = b;
                     } else {


### PR DESCRIPTION
Workaround for https://github.com/kermitt2/grobid/issues/683

Some documents have a higher line length, beyond the hard-coded `15`. That caused the figure caption to only contain the first line.

This can now be disable via the feature flag `no_figure_distance_rules` (e.g. `GROBID__FEATURES__NO_FIGURE_DISTANCE_RULES=true`).