### PR TITLE
disabled update of figure caption

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -946,10 +946,12 @@ public class Document implements Serializable {
             for (Figure f : figureMap.get(pageNum)) {
                 List<LayoutToken> realCaptionTokens = getFigureLayoutTokens(f);
                 if (realCaptionTokens != null && !realCaptionTokens.isEmpty()) {
-                    f.setLayoutTokens(realCaptionTokens);
-                    f.setTextArea(BoundingBoxCalculator.calculate(realCaptionTokens));
-                    f.setCaption(new StringBuilder(LayoutTokensUtil.toText(LayoutTokensUtil.dehyphenize(realCaptionTokens))));
-                    f.setCaptionLayoutTokens(realCaptionTokens);
+                    if (!GrobidProperties.isFeatureFlag("no_figure_update_caption")) {
+                        f.setLayoutTokens(realCaptionTokens);
+                        f.setTextArea(BoundingBoxCalculator.calculate(realCaptionTokens));
+                        f.setCaption(new StringBuilder(LayoutTokensUtil.toText(LayoutTokensUtil.dehyphenize(realCaptionTokens))));
+                        f.setCaptionLayoutTokens(realCaptionTokens);
+                    }
                     pageFigures.add(f);
                 }
             }


### PR DESCRIPTION
Workaround for https://github.com/elifesciences/sciencebeam-issues/issues/83

And also https://github.com/kermitt2/grobid/issues/683#issuecomment-757020128

The update of the figure caption can be disabled via the `no_figure_update_caption` feature flag. (`GROBID__FEATURES__NO_FIGURE_UPDATE_CAPTION=true`)