### PR TITLE
fixed fulltext BLOCKSTART with first block token being whitespace

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -308,14 +308,10 @@ public class FullTextParser extends AbstractParser {
         }
     }
 
-    /**
-     * Process a simple segment of layout tokens with the full text model.
-     * Return null if provided Layout Tokens is empty or if structuring failed. 
-     */
-    public Pair<String, List<LayoutToken>> processShortNew(List<LayoutToken> tokens, Document doc) {
-        if (CollectionUtils.isEmpty(tokens))
-            return null;
-
+    public SortedSet<DocumentPiece> getDocumentPartsForLayoutTokens(
+        Document doc,
+        List<LayoutToken> tokens
+    ) {
         SortedSet<DocumentPiece> documentParts = new TreeSet<DocumentPiece>();
         // identify continuous sequence of layout tokens in the abstract
         int posStartPiece = -1;
@@ -352,6 +348,18 @@ public class FullTextParser extends AbstractParser {
             DocumentPiece piece = new DocumentPiece(dp1, dp2);
             documentParts.add(piece);
         }
+        return documentParts;
+    }
+
+    /**
+     * Process a simple segment of layout tokens with the full text model.
+     * Return null if provided Layout Tokens is empty or if structuring failed. 
+     */
+    public Pair<String, List<LayoutToken>> processShortNew(List<LayoutToken> tokens, Document doc) {
+        if (CollectionUtils.isEmpty(tokens))
+            return null;
+
+        SortedSet<DocumentPiece> documentParts = getDocumentPartsForLayoutTokens(doc, tokens);
 
         Pair<String, LayoutTokenization> featSeg = getBodyTextFeatured(doc, documentParts);
         String res = "";

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -623,6 +623,7 @@ public class FullTextParser extends AbstractParser {
 					}
 				}
 
+                boolean isFirstBlockToken = true;
 	            while (n < lastPos) {
 					if (blockIndex == dp2.getBlockPtr()) {
 						//if (n > block.getEndToken()) {
@@ -740,7 +741,7 @@ public class FullTextParser extends AbstractParser {
 	                	features.alignmentStatus = "ALIGNEDLEFT";
 	                }
 
-	                if (n == 0) {
+	                if (isFirstBlockToken) {
 	                    features.lineStatus = "LINESTART";
 	                    // be sure that previous token is closing a line, except if it's a starting line
 	                    if (previousFeatures != null) {
@@ -917,6 +918,7 @@ public class FullTextParser extends AbstractParser {
 	                mm += text.length();
 	                nn += text.length();
 	                previousFeatures = features;
+                    isFirstBlockToken = false;
             	}
                 // lowest position of the block
                 lowestPos = block.getY() + block.getHeight();

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -308,10 +308,14 @@ public class FullTextParser extends AbstractParser {
         }
     }
 
-    public SortedSet<DocumentPiece> getDocumentPartsForLayoutTokens(
-        Document doc,
-        List<LayoutToken> tokens
-    ) {
+    /**
+     * Process a simple segment of layout tokens with the full text model.
+     * Return null if provided Layout Tokens is empty or if structuring failed. 
+     */
+    public Pair<String, List<LayoutToken>> processShortNew(List<LayoutToken> tokens, Document doc) {
+        if (CollectionUtils.isEmpty(tokens))
+            return null;
+
         SortedSet<DocumentPiece> documentParts = new TreeSet<DocumentPiece>();
         // identify continuous sequence of layout tokens in the abstract
         int posStartPiece = -1;
@@ -348,18 +352,6 @@ public class FullTextParser extends AbstractParser {
             DocumentPiece piece = new DocumentPiece(dp1, dp2);
             documentParts.add(piece);
         }
-        return documentParts;
-    }
-
-    /**
-     * Process a simple segment of layout tokens with the full text model.
-     * Return null if provided Layout Tokens is empty or if structuring failed. 
-     */
-    public Pair<String, List<LayoutToken>> processShortNew(List<LayoutToken> tokens, Document doc) {
-        if (CollectionUtils.isEmpty(tokens))
-            return null;
-
-        SortedSet<DocumentPiece> documentParts = getDocumentPartsForLayoutTokens(doc, tokens);
 
         Pair<String, LayoutTokenization> featSeg = getBodyTextFeatured(doc, documentParts);
         String res = "";

--- a/grobid-core/src/test/java/org/grobid/core/engines/FullTextParserTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/FullTextParserTest.java
@@ -1,11 +1,13 @@
 package org.grobid.core.engines;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.grobid.core.analyzers.GrobidAnalyzer;
 import org.grobid.core.document.Document;
 import org.grobid.core.document.DocumentPiece;
 import org.grobid.core.factory.GrobidFactory;
 import org.grobid.core.layout.Block;
 import org.grobid.core.layout.LayoutToken;
+import org.grobid.core.layout.LayoutTokenization;
 import org.grobid.core.main.LibraryLoader;
 import org.grobid.core.utilities.GrobidProperties;
 import org.junit.AfterClass;
@@ -14,12 +16,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 
 import static org.easymock.EasyMock.*;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
@@ -41,6 +45,18 @@ public class FullTextParserTest {
     @AfterClass
     public static void tearDown() {
         GrobidFactory.reset();
+    }
+
+    @Test
+    public void testShouldOutputBlockStartForRegularBlock() throws Exception {
+        String blockText = "This is a block";
+        Document doc = Document.createFromText(blockText);
+        Block block = doc.getBlocks().get(0);
+        List<LayoutToken> layoutTokens = block.getTokens();
+        SortedSet<DocumentPiece> documentParts = target.getDocumentPartsForLayoutTokens(doc, layoutTokens);
+        Pair<String, LayoutTokenization> dataAndTokens = FullTextParser.getBodyTextFeatured(doc, documentParts);
+        String[] lines = dataAndTokens.getLeft().split("\n");
+        assertThat("lines[0] fields", Arrays.asList(lines[0].split("\\s")), is(hasItem("BLOCKSTART")));
     }
 
 //    @Test

--- a/grobid-core/src/test/java/org/grobid/core/engines/FullTextParserTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/FullTextParserTest.java
@@ -83,6 +83,11 @@ public class FullTextParserTest {
     public void testShouldOutputBlockStartForBlockStartingWithLineFeed() throws Exception {
         String blockText = "\nThis is a block";
         Document doc = Document.createFromText(blockText);
+        assertThat(
+            "doc.block[0].tokens[0].text",
+            doc.getBlocks().get(0).getTokens().get(0).getText(),
+            is("\n")
+        );
         SortedSet<DocumentPiece> documentParts = getWholeDocumentParts(doc);
         Pair<String, LayoutTokenization> dataAndTokens = FullTextParser.getBodyTextFeatured(doc, documentParts);
         LOGGER.debug("data debug: {}", dataAndTokens.getLeft());

--- a/grobid-core/src/test/java/org/grobid/core/engines/FullTextParserTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/FullTextParserTest.java
@@ -80,7 +80,6 @@ public class FullTextParserTest {
     }
 
     @Test
-    @Ignore(value="currently failing")
     public void testShouldOutputBlockStartForBlockStartingWithLineFeed() throws Exception {
         String blockText = "\nThis is a block";
         Document doc = Document.createFromText(blockText);


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/99
upstream PR: https://github.com/kermitt2/grobid/pull/714