### PR TITLE
added low token length ratio check

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -421,6 +421,16 @@ public class Document implements Serializable {
             throw new GrobidException("PDF parsing resulted in empty content", GrobidExceptionStatus.NO_BLOCKS);
         }
 
+        if (GrobidProperties.isFeatureFlag("clear_document_if_low_token_length_ratio")) {
+            TokenLengthRatioFilter tokenLengthRatioFilter = new TokenLengthRatioFilter();
+            double tokenLengthRatio = tokenLengthRatioFilter.getNonBlankTokenLengthRatio(this.getBlocks());
+            if (tokenLengthRatio < 1.5) {
+                LOGGER.info("clearing document due to token length ratio: {}", tokenLengthRatio);
+                tokenLengthRatioFilter.clearBlocks(this.getBlocks());
+                tokenizations = new ArrayList<LayoutToken>();
+            }
+        }
+
         // we filter out possible line numbering for review works
         if (GrobidProperties.isFeatureFlag("remove_line_numbers")) {
             LineNumberFilter lineNumberFilter = new LineNumberFilter();

--- a/grobid-core/src/main/java/org/grobid/core/document/TokenLengthRatioFilter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TokenLengthRatioFilter.java
@@ -1,0 +1,63 @@
+package org.grobid.core.document;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.grobid.core.layout.Block;
+import org.grobid.core.layout.LayoutToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+class TokenLengthRatioFilter {
+    public static final Logger logger = LoggerFactory.getLogger(TokenLengthRatioFilter.class);
+
+    public List<LayoutToken> getFlatNonBlankTokenList(List<Block> blocks) {
+        if (blocks == null) {
+            return Collections.emptyList();
+        }
+        return (
+            blocks
+            .stream()
+            .flatMap(block -> block.getTokens().stream())
+            .filter(layoutToken -> !StringUtils.isBlank(layoutToken.getText()))
+            .collect(Collectors.toList())
+        );
+    }
+
+    public double getTokenLengthRatio(List<LayoutToken> layoutTokens) {
+        long totalCharacterCount = (
+            layoutTokens
+            .stream()
+            .mapToLong(layoutToken -> layoutToken.getText().length())
+            .sum()
+        );
+        double ratio = ((double) totalCharacterCount) / layoutTokens.size();
+        logger.info(
+            "total token characters: {}, number of tokens: {}, ratio: {}",
+            totalCharacterCount, layoutTokens.size(), ratio
+        );
+        return ratio;
+    }
+
+    public double getNonBlankTokenLengthRatio(List<Block> blocks) {
+        return this.getTokenLengthRatio(
+            this.getFlatNonBlankTokenList(blocks)
+        );
+    }
+
+    public void clearBlock(Block block) {
+        block.resetTokens();
+    }
+
+    public void clearBlocks(List<Block> blocks) {
+        if (blocks == null) {
+            return;
+        }
+        for (Block block: blocks) {
+            this.clearBlock(block);
+        }
+    }
+}

--- a/grobid-core/src/test/java/org/grobid/core/document/TokenLengthRatioFilterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/TokenLengthRatioFilterTest.java
@@ -1,0 +1,73 @@
+package org.grobid.core.document;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.grobid.core.layout.Block;
+import org.grobid.core.layout.LayoutToken;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class TokenLengthRatioFilterTest {
+    public static final Logger LOGGER = LoggerFactory.getLogger(TokenLengthRatioFilterTest.class);
+
+    private TokenLengthRatioFilter filter = new TokenLengthRatioFilter();
+
+    public TokenLengthRatioFilterTest() {
+    }
+
+    private List<LayoutToken> createTokens(List<String> textList) {
+        return (
+            textList
+            .stream()
+            .map(text -> new LayoutToken(text))
+            .collect(Collectors.toList())
+        );
+    }
+
+    private Block createBlock(List<LayoutToken> tokens) {
+        Block block = new Block();
+        for (LayoutToken token: tokens) {
+            block.addToken(token);
+        }
+        return block;
+    }
+
+    @Test
+    public void shouldNotFailOnNullBlocks() {
+        double ratio = this.filter.getNonBlankTokenLengthRatio(null);
+        assertThat("ratio", ratio, is(Double.NaN));
+        assertThat("ratio < 2", ratio < 2, is(false));
+        this.filter.clearBlocks(null);
+    }
+
+    @Test
+    public void shouldCalculateRatioForSingleBlock() {
+        Block block = createBlock(this.createTokens(Arrays.asList(
+            "12345678", "1234"
+        )));
+        assertThat(
+            "ratio",
+            this.filter.getNonBlankTokenLengthRatio(Arrays.asList(block)),
+            is(6.0)  // (8 + 4) / 2
+        );
+    }
+
+    @Test
+    public void shouldCalculateFractionalRatioForSingleBlock() {
+        Block block = createBlock(this.createTokens(Arrays.asList(
+            "1234567", "1234"
+        )));
+        assertThat(
+            "ratio",
+            this.filter.getNonBlankTokenLengthRatio(Arrays.asList(block)),
+            is(5.5)  // (7 + 4) / 2
+        );
+    }
+}


### PR DESCRIPTION
part of https://github.com/elifesciences/sciencebeam-issues/issues/112

This is to allow responding with an empty document instead, if it seems to be encountering the character spacing issue affecting the whole document (https://github.com/kermitt2/pdfalto/issues/111).

To enable, set the `clear_document_if_low_token_length_ratio` feature flag, e.g. by via `GROBID__FEATURES__CLEAR_DOCUMENT_IF_LOW_TOKEN_LENGTH_RATIO=true`.

It will then clear the document if the token length ratio of non-empty / blank tokens is below `1.5`.